### PR TITLE
python actionloop v3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ deploy:
       all_branches: true
       repo: apache/incubator-openwhisk-runtime-python
   - provider: script
-    script: "./tools/travis/publish.sh openwhisk 2 latest && ./tools/travis/publish.sh openwhisk 3 latest && ./tools/travis/publish.sh openwhisk 3-ai latest"
+    script: "./tools/travis/publish.sh openwhisk 2 latest && ./tools/travis/publish.sh openwhisk 3 latest && ./tools/travis/publish.sh openwhisk 3-ai latest && ./tools/travis/publish.sh openwhisk 3-loop latest"
     on:
       branch: master
       repo: apache/incubator-openwhisk-runtime-python

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,11 @@ scala:
 - 2.12.7
 services:
   - docker
+# required to support multi-stage build
+addons:
+   apt:
+     packages:
+       - docker-ce
 before_install:
   - "./tools/travis/setup.sh"
 install: true
@@ -39,3 +44,4 @@ notifications:
     urls:
       # travis2slack webhook to enable DMs on openwhisk-team.slack.com to PR authors with TravisCI results
       secure: "jhiMGpQ6kJFWjjsO68RmgD2Lga7jgNE+EKwND0dMOvzf5llMLFDKcY5J3tgtrqYaslQdXeuYeru/9qJrTTjFEu+vz3iCwoJ/eme+D0TtTIFGlPr7oa9tZlWrkPM/0zFLq7KjJauIIX2+6qrGVrNJJ6ENfr4U8Ir8q51oLIk44bsCeB8EmkahPOlNG6kcNqgpxHWKYUdUIg3B0GxqCKida/76dXDTRHCV2dZuT2bXz2oSJYog/lybomsjQIUZj0+HqxecgWTzag3Y6rTpK+m+vywazHP91hE+oU4e7YrxCH6v9+ukoWaljFqO5ZEKXcpx6tzx8Q0FvoTP8vGOO9b/t1loVcA8OxSJDrtOAztfoz/u0HJN6vnVt+maqnrYAD1F4pxA63JA6/+a7firmtADP7A/WQMZg6RgEkGUr+amFn303dTvgjDDkZ4oH8MAr0EPsneGUA2MZgB3i1MEcnCrYzT7KpYmDmFLoFhS9OX8f1H3zi5DLZZbZ1jbW/Ay4BgvjdoC8vmhAsDfVvyY9P240+nQ9NrnjaAUMD4XI/6JAKekfoxvsnc9W8gKBGTNfzi55AVe7HbzB/wCd58c2CV3Ev3RRwKQpH67jLBROpg2ocRQr0BUeHmfOT7NV4BCqdw1eVkZWBw4oxVaCHelDdICwgPn696W5t/1UVl4tLTt1rk="
+

--- a/core/pythonActionLoop/Dockerfile
+++ b/core/pythonActionLoop/Dockerfile
@@ -1,0 +1,42 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+FROM openwhisk/actionloop:latest as builder
+
+FROM python:3.7-stretch
+
+# Install common modules for python
+RUN pip install \
+    beautifulsoup4==4.6.3 \
+    httplib2==0.11.3 \
+    kafka_python==1.4.3 \
+    lxml==4.2.5 \
+    python-dateutil==2.7.3 \
+    requests==2.19.1 \
+    scrapy==1.5.1 \
+    simplejson==3.16.0 \
+    virtualenv==16.0.0 \
+    twisted==18.7.0
+
+RUN mkdir -p /action
+WORKDIR /
+COPY --from=builder /bin/proxy /bin/proxy
+ADD pythonbuild.py /bin/compile
+ADD pythonbuild.py.launcher.py /bin/compile.launcher.py
+ENV OW_COMPILER=/bin/compile
+ENTRYPOINT []
+CMD ["/bin/proxy"]
+

--- a/core/pythonActionLoop/build.gradle
+++ b/core/pythonActionLoop/build.gradle
@@ -15,26 +15,5 @@
  * limitations under the License.
  */
 
-include 'tests'
-
-include 'core:pythonAction'
-include 'core:python2Action'
-include 'core:python3AiAction'
-include 'core:pythonActionLoop'
-
-
-rootProject.name = 'runtime-python'
-
-gradle.ext.openwhisk = [
-        version: '1.0.0-SNAPSHOT'
-]
-
-gradle.ext.scala = [
-    version: '2.12.7',
-    compileFlags: ['-feature', '-unchecked', '-deprecation', '-Xfatal-warnings', '-Ywarn-unused-import']
-]
-
-gradle.ext.scalafmt = [
-    version: '1.5.0',
-    config: new File(rootProject.projectDir, '.scalafmt.conf')
-]
+ext.dockerImageName = 'actionloop-python-v3.7'
+apply from: '../../gradle/docker.gradle'

--- a/core/pythonActionLoop/pythonbuild.py
+++ b/core/pythonActionLoop/pythonbuild.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Python Action Compiler
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+
+from __future__ import print_function
+import os
+import sys
+import codecs
+import subprocess
+
+
+def copy(src, dst):
+    with codecs.open(src, 'r', 'utf-8') as s:
+        body = s.read()
+        with codecs.open(dst, 'w', 'utf-8') as d:
+            d.write(body)
+
+# if there is an exec copy to main__.py
+# else if there is a __main__.py copy to main__.py
+# (exec prevails over __main__.py)
+# then copy the launcher in exec__.py replacing the main function
+def sources(launcher, source_dir, main):
+    # source and dest
+    src = "%s/exec" % source_dir
+    dst = "%s/main__.py" % source_dir
+    # copy exec to main__.py
+    if os.path.isfile(src):
+        copy(src,dst)
+    else:
+        # renaming __main__ to main__
+        src = "%s/__main__.py" % source_dir
+        if os.path.isfile(src):
+            copy(src, dst)
+
+    # copy a launcher
+    starter = "%s/exec__.py" % source_dir
+    with codecs.open(launcher, 'r', 'utf-8') as s:
+        with codecs.open(starter, 'w', 'utf-8') as d:
+            body = s.read()
+            body = body.replace("from main__ import main as main",
+                                "from main__ import %s as main" % main)
+            d.write(body)
+    return starter
+
+# build the launcher but only if there is the main
+def build(source_dir, target_file, launcher):
+    main = "%s/main__.py" % source_dir
+    cmd = "#!/bin/bash"
+    if os.path.isfile(main):
+        cmd += """
+cd %s
+exec python %s "$@"
+""" % (source_dir, launcher)
+    else:
+        cmd += """
+echo "Zip file does not include mandatory files."
+"""
+    with codecs.open(target_file, 'w', 'utf-8') as d:
+        d.write(cmd)
+    os.chmod(target_file, 0o755)
+
+def compile(argv):
+    if len(argv) < 4:
+        sys.stdout.write("usage: <main-function> <source-dir> <target-dir>\n")
+        sys.exit(1)
+
+    main = argv[1]
+    source_dir = os.path.abspath(argv[2])
+    target_file = os.path.abspath("%s/exec" % argv[3])
+    launcher = os.path.abspath(argv[0]+".launcher.py")
+    starter = sources(launcher, source_dir, main)
+    build(source_dir, target_file, starter)
+    sys.stdout.flush()
+    sys.stderr.flush()
+    return target_file
+
+
+if __name__ == '__main__':
+    p = subprocess.Popen([compile(sys.argv), "exit"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE)
+    (o, e) = p.communicate()
+    if isinstance(o, bytes) and not isinstance(o, str):
+        o = o.decode('utf-8')
+    if isinstance(e, bytes) and not isinstance(e, str):
+        e = e.decode('utf-8')
+    if o:
+        sys.stdout.write(o)
+        sys.stdout.flush()
+
+    if e:
+        sys.stderr.write(e)
+        sys.stderr.flush()
+

--- a/core/pythonActionLoop/pythonbuild.py.launcher.py
+++ b/core/pythonActionLoop/pythonbuild.py.launcher.py
@@ -1,0 +1,72 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from __future__ import print_function
+from sys import stdin
+from sys import stdout
+from sys import stderr
+from os import fdopen
+import sys, os, json, traceback
+
+try:
+  # if the directory 'virtualenv' is extracted out of a zip file
+  path_to_virtualenv = os.path.abspath('./virtualenv')
+  if os.path.isdir(path_to_virtualenv):
+    # activate the virtualenv using activate_this.py contained in the virtualenv
+    activate_this_file = path_to_virtualenv + '/bin/activate_this.py'
+    if os.path.exists(activate_this_file):
+      with open(activate_this_file) as f:
+        code = compile(f.read(), activate_this_file, 'exec')
+        exec(code, dict(__file__=activate_this_file))
+    else:
+      sys.stderr.write('Invalid virtualenv. Zip file does not include /virtualenv/bin/' + os.path.basename(activate_this_file) + '\n')
+      sys.exit(1)
+except Exception:
+  traceback.print_exc(file=sys.stderr, limit=0)
+  sys.exit(1)
+
+# now import the action as process input/output
+from main__ import main as main
+
+# if there are some arguments exit immediately
+if len(sys.argv) >1:
+  sys.stderr.flush()
+  sys.stdout.flush()
+  sys.exit(0)
+
+env = os.environ
+out = fdopen(3, "wb")
+while True:
+  line = stdin.readline()
+  if not line: break
+  args = json.loads(line)
+  payload = {}
+  for key in args:
+    if key == "value":
+      payload = args["value"]
+    else:
+      env["__OW_%s" % key.upper()]= args[key]
+  res = {}
+  try:
+    res = main(payload)
+  except Exception as ex:
+    print(traceback.format_exc(), file=stderr)
+    res = {"error": str(ex)}
+  out.write(json.dumps(res, ensure_ascii=False).encode('utf-8'))
+  out.write(b'\n')
+  stdout.flush()
+  stderr.flush()
+  out.flush()

--- a/tests/src/test/scala/runtime/actionContainers/PythonActionContainerTests.scala
+++ b/tests/src/test/scala/runtime/actionContainers/PythonActionContainerTests.scala
@@ -206,27 +206,30 @@ class PythonActionContainerTests extends BasicActionRunnerTests with WskActorSys
           e should include("Zip file does not include")
       })
   }
-  /*
-    it should "run zipped Python action containing a virtual environment" in {
-      val zippedPythonAction = if (imageName == "python2action") "python2_virtualenv.zip" else "python3_virtualenv.zip"
-      val zippedPythonActionName = TestUtils.getTestActionFilename(zippedPythonAction)
-      val code = readAsBase64(Paths.get(zippedPythonActionName))
 
-      val (out, err) = withActionContainer() { c =>
-        val (initCode, initRes) = c.init(initPayload(code, main = "main"))
-        initCode should be(200)
-        val args = JsObject("msg" -> JsString("any"))
-        val (runCode, runRes) = c.run(runPayload(args))
-        runCode should be(200)
-        runRes.get.toString() should include("netmask")
-      }
-      checkStreams(out, err, {
-        case (o, e) =>
-          o should include("netmask")
-          e shouldBe empty
-      })
+  it should "run zipped Python action containing a virtual environment" in {
+    val zippedPythonAction =
+      if (imageName == "python2action") "python2_virtualenv.zip"
+      else if (imageName == "actionloop-python-v3.7") "python37_virtualenv.zip"
+      else "python3_virtualenv.zip"
+    val zippedPythonActionName = TestUtils.getTestActionFilename(zippedPythonAction)
+    val code = readAsBase64(Paths.get(zippedPythonActionName))
+
+    val (out, err) = withActionContainer() { c =>
+      val (initCode, initRes) = c.init(initPayload(code, main = "main"))
+      initCode should be(200)
+      val args = JsObject("msg" -> JsString("any"))
+      val (runCode, runRes) = c.run(runPayload(args))
+      runCode should be(200)
+      runRes.get.toString() should include("netmask")
     }
-   */
+
+    checkStreams(out, err, {
+      case (o, e) =>
+        o should include("netmask")
+        e shouldBe empty
+    })
+  }
 
   it should "run zipped Python action containing a virtual environment with non-standard entry point" in {
     val zippedPythonAction =
@@ -235,24 +238,21 @@ class PythonActionContainerTests extends BasicActionRunnerTests with WskActorSys
       else "python3_virtualenv.zip"
     val zippedPythonActionName = TestUtils.getTestActionFilename(zippedPythonAction)
 
-    // temporary guard to comment out this test
-    // until python37_virtualenv.zip is available in main repo
-    if (initErrorsAreLogged) {
-      val code = readAsBase64(Paths.get(zippedPythonActionName))
-      val (out, err) = withActionContainer() { c =>
-        val (initCode, initRes) = c.init(initPayload(code, main = "naim"))
-        initCode should be(200)
-        val args = JsObject("msg" -> JsString("any"))
-        val (runCode, runRes) = c.run(runPayload(args))
-        runCode should be(200)
-        runRes.get.toString() should include("netmask")
-      }
-      checkStreams(out, err, {
-        case (o, e) =>
-          o should include("netmask")
-          e shouldBe empty
-      })
+    val code = readAsBase64(Paths.get(zippedPythonActionName))
+    val (out, err) = withActionContainer() { c =>
+      val (initCode, initRes) = c.init(initPayload(code, main = "naim"))
+      initCode should be(200)
+      val args = JsObject("msg" -> JsString("any"))
+      val (runCode, runRes) = c.run(runPayload(args))
+      runCode should be(200)
+      runRes.get.toString() should include("netmask")
     }
+    checkStreams(out, err, {
+      case (o, e) =>
+        o should include("netmask")
+        e shouldBe empty
+    })
+
   }
 
   it should "report error if zipped Python action containing a virtual environment for wrong python version" in {

--- a/tests/src/test/scala/runtime/actionContainers/PythonActionLoopContainerTests.scala
+++ b/tests/src/test/scala/runtime/actionContainers/PythonActionLoopContainerTests.scala
@@ -15,26 +15,22 @@
  * limitations under the License.
  */
 
-include 'tests'
+package runtime.actionContainers
 
-include 'core:pythonAction'
-include 'core:python2Action'
-include 'core:python3AiAction'
-include 'core:pythonActionLoop'
+import common.WskActorSystem
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
 
+@RunWith(classOf[JUnitRunner])
+class PythonActionLoopContainerTests extends PythonActionContainerTests with WskActorSystem {
 
-rootProject.name = 'runtime-python'
+  override lazy val imageName = "actionloop-python-v3.7"
 
-gradle.ext.openwhisk = [
-        version: '1.0.0-SNAPSHOT'
-]
+  override val testNoSource = TestConfig("", hasCodeStub = false)
 
-gradle.ext.scala = [
-    version: '2.12.7',
-    compileFlags: ['-feature', '-unchecked', '-deprecation', '-Xfatal-warnings', '-Ywarn-unused-import']
-]
+  /** indicates if strings in python are unicode by default (i.e., python3 -> true, python2.7 -> false) */
+  override lazy val pythonStringAsUnicode = true
 
-gradle.ext.scalafmt = [
-    version: '1.5.0',
-    config: new File(rootProject.projectDir, '.scalafmt.conf')
-]
+  /** actionloop based image does not log init errors - return the error in the body */
+  override lazy val initErrorsAreLogged = false
+}

--- a/tools/travis/publish.sh
+++ b/tools/travis/publish.sh
@@ -36,6 +36,8 @@ elif [ ${RUNTIME_VERSION} == "3" ]; then
   RUNTIME="pythonAction"
 elif [ ${RUNTIME_VERSION} == "3-ai" ]; then
   RUNTIME="python3AiAction"
+elif [ ${RUNTIME_VERSION} == "3-loop" ]; then
+  RUNTIME="pythonActionLoop"
 fi
 
 if [[ ! -z ${DOCKER_USER} ]] && [[ ! -z ${DOCKER_PASSWORD} ]]; then


### PR DESCRIPTION
This PR implements an ActionLoop based runtime.
It tries to be as backward compatible as possible.
The main differences are in the way init errors are reported, actionloop reports them at init time in the answer while the current python logs them. 
Also, the runtime does not set the code to 502 when there is an error response.
Please merge PR#4193 on incubator-openwhisk as there is a required file to run the tests.

