### PR TITLE
move global variables initialized to init

### DIFF
--- a/core/python3AiAction/Dockerfile
+++ b/core/python3AiAction/Dockerfile
@@ -56,6 +56,6 @@ RUN mkdir -p /actionProxy
 ADD https://raw.githubusercontent.com/apache/incubator-openwhisk-runtime-docker/dockerskeleton%401.3.3/core/actionProxy/actionproxy.py /actionProxy/actionproxy.py
 
 RUN mkdir -p /pythonAction
-ADD https://raw.githubusercontent.com/apache/incubator-openwhisk-runtime-python/3%401.0.3/core/pythonAction/pythonrunner.py /pythonAction/pythonrunner.py
+COPY ../pythonAction/pythonrunner.py /pythonAction/pythonrunner.py
 
 CMD ["/bin/bash", "-c", "cd /pythonAction && python -u pythonrunner.py"]

--- a/core/python3AiAction/Dockerfile
+++ b/core/python3AiAction/Dockerfile
@@ -56,6 +56,6 @@ RUN mkdir -p /actionProxy
 ADD https://raw.githubusercontent.com/apache/incubator-openwhisk-runtime-docker/dockerskeleton%401.3.3/core/actionProxy/actionproxy.py /actionProxy/actionproxy.py
 
 RUN mkdir -p /pythonAction
-COPY ../pythonAction/pythonrunner.py /pythonAction/pythonrunner.py
+COPY pythonrunner.py /pythonAction/pythonrunner.py
 
 CMD ["/bin/bash", "-c", "cd /pythonAction && python -u pythonrunner.py"]

--- a/core/python3AiAction/pythonrunner.py
+++ b/core/python3AiAction/pythonrunner.py
@@ -1,0 +1,100 @@
+"""Executable Python script for running Python actions.
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+"""
+
+import os
+import sys
+import codecs
+import traceback
+sys.path.append('../actionProxy')
+from actionproxy import ActionRunner, main, setRunner
+
+
+class PythonRunner(ActionRunner):
+
+    def __init__(self):
+        ActionRunner.__init__(self, '/action/__main__.py')
+        self.fn = None
+        self.mainFn = 'main'
+        self.global_context = {}
+
+    def initCodeFromString(self, message):
+        # do nothing, defer to build step
+        return True
+
+    def build(self, message):
+        binary = message['binary'] if 'binary' in message else False
+        if not binary:
+            code = message['code']
+            filename = 'action'
+        elif os.path.isfile(self.source):
+            with codecs.open(self.source, 'r', 'utf-8') as m:
+                code = m.read()
+            workdir = os.path.dirname(self.source)
+            sys.path.insert(0, workdir)
+            os.chdir(workdir)
+        else:
+            sys.stderr.write('Zip file does not include ' + os.path.basename(self.source) + '\n')
+            return False
+
+        try:
+            filename = os.path.basename(self.source)
+            self.fn = compile(code, filename=filename, mode='exec')
+            if 'main' in message:
+                self.mainFn = message['main']
+
+            # if the directory 'virtualenv' is extracted out of a zip file
+            path_to_virtualenv = os.path.dirname(self.source) + '/virtualenv'
+            if os.path.isdir(path_to_virtualenv):
+                # activate the virtualenv using activate_this.py contained in the virtualenv
+                activate_this_file = path_to_virtualenv + '/bin/activate_this.py'
+                if os.path.exists(activate_this_file):
+                    with open(activate_this_file) as f:
+                        code = compile(f.read(), activate_this_file, 'exec')
+                        exec(code, dict(__file__=activate_this_file))
+                else:
+                    sys.stderr.write('Invalid virtualenv. Zip file does not include /virtualenv/bin/' + os.path.basename(activate_this_file) + '\n')
+                    return False
+            exec(self.fn, self.global_context)
+            return True
+        except Exception:
+            traceback.print_exc(file=sys.stderr, limit=0)
+            return False
+
+    def verify(self):
+        return self.fn is not None
+
+    def run(self, args, env):
+        result = None
+        try:
+            os.environ = env
+            self.global_context['param'] = args
+            exec('fun = %s(param)' % self.mainFn, self.global_context)
+            result = self.global_context['fun']
+        except Exception:
+            traceback.print_exc(file=sys.stderr)
+
+        if result and isinstance(result, dict):
+            return (200, result)
+        else:
+            return (502, {'error': 'The action did not return a dictionary.'})
+
+if __name__ == '__main__':
+    setRunner(PythonRunner())
+    main()

--- a/core/pythonAction/pythonrunner.py
+++ b/core/pythonAction/pythonrunner.py
@@ -55,8 +55,7 @@ class PythonRunner(ActionRunner):
 
         try:
             filename = os.path.basename(self.source)
-            self.fn = compile(code, filename=filename, mode='exec')
-            exec(self.fn, self.global_context)
+            self.fn = compile(code, filename=filename, mode='exec')            
             if 'main' in message:
                 self.mainFn = message['main']
 
@@ -72,6 +71,7 @@ class PythonRunner(ActionRunner):
                 else:
                     sys.stderr.write('Invalid virtualenv. Zip file does not include /virtualenv/bin/' + os.path.basename(activate_this_file) + '\n')
                     return False
+            exec(self.fn, self.global_context)
             return True
         except Exception:
             traceback.print_exc(file=sys.stderr, limit=0)

--- a/core/pythonAction/pythonrunner.py
+++ b/core/pythonAction/pythonrunner.py
@@ -55,7 +55,7 @@ class PythonRunner(ActionRunner):
 
         try:
             filename = os.path.basename(self.source)
-            self.fn = compile(code, filename=filename, mode='exec')            
+            self.fn = compile(code, filename=filename, mode='exec')
             if 'main' in message:
                 self.mainFn = message['main']
 

--- a/core/pythonAction/pythonrunner.py
+++ b/core/pythonAction/pythonrunner.py
@@ -56,6 +56,7 @@ class PythonRunner(ActionRunner):
         try:
             filename = os.path.basename(self.source)
             self.fn = compile(code, filename=filename, mode='exec')
+            exec(self.fn, self.global_context)
             if 'main' in message:
                 self.mainFn = message['main']
 
@@ -84,7 +85,6 @@ class PythonRunner(ActionRunner):
         try:
             os.environ = env
             self.global_context['param'] = args
-            exec(self.fn, self.global_context)
             exec('fun = %s(param)' % self.mainFn, self.global_context)
             result = self.global_context['fun']
         except Exception:

--- a/tests/src/test/scala/runtime/actionContainers/PythonActionContainerTests.scala
+++ b/tests/src/test/scala/runtime/actionContainers/PythonActionContainerTests.scala
@@ -268,9 +268,6 @@ class PythonActionContainerTests extends BasicActionRunnerTests with WskActorSys
         val (initCode, initRes) = c.init(initPayload(code, main = "main"))
         if (initErrorsAreLogged) {
           initCode should be(502)
-          val args = JsObject("msg" -> JsString("any"))
-          val (runCode, runRes) = c.run(runPayload(args))
-          runCode should be(502)
         } else {
           // it actually means it is actionloop
           // it checks the error at init time
@@ -421,9 +418,6 @@ class PythonActionContainerTests extends BasicActionRunnerTests with WskActorSys
       if (initErrorsAreLogged) {
         val (initCode, res) = c.init(initPayload(code))
         initCode should be(502)
-
-        val (runCode, runRes) = c.run(runPayload(JsObject()))
-        runCode should be(502)
       } else {
         // action loop detects those errors at init time
         val (initCode, initRes) = c.init(initPayload(code))

--- a/tests/src/test/scala/runtime/actionContainers/PythonActionContainerTests.scala
+++ b/tests/src/test/scala/runtime/actionContainers/PythonActionContainerTests.scala
@@ -267,7 +267,7 @@ class PythonActionContainerTests extends BasicActionRunnerTests with WskActorSys
       val (out, err) = withActionContainer() { c =>
         val (initCode, initRes) = c.init(initPayload(code, main = "main"))
         if (initErrorsAreLogged) {
-          initCode should be(200)
+          initCode should be(502)
           val args = JsObject("msg" -> JsString("any"))
           val (runCode, runRes) = c.run(runPayload(args))
           runCode should be(502)
@@ -420,7 +420,7 @@ class PythonActionContainerTests extends BasicActionRunnerTests with WskActorSys
 
       if (initErrorsAreLogged) {
         val (initCode, res) = c.init(initPayload(code))
-        initCode should be(200)
+        initCode should be(502)
 
         val (runCode, runRes) = c.run(runPayload(JsObject()))
         runCode should be(502)


### PR DESCRIPTION
Moving part of the time-consuming processing to the init phase reduces the execution time of the action. For example, deep learning requires loading a model with a larger specification. Load the model outside of the mian function to avoid loading it every time it is executed.
example:
x = 1
def main(args):
       return args
x=1 will be executed in init