### PR TITLE
exec fn outside the main function at action init

### DIFF
--- a/core/pythonAction/pythonrunner.py
+++ b/core/pythonAction/pythonrunner.py
@@ -71,8 +71,8 @@ class PythonRunner(ActionRunner):
                 else:
                     sys.stderr.write('Invalid virtualenv. Zip file does not include /virtualenv/bin/' + os.path.basename(activate_this_file) + '\n')
                     return False
-            #exec global var define when action init    
-            exec(self.fn, self.global_context)    
+            #exec global var define when action init
+            exec(self.fn, self.global_context)
             return True
         except Exception:
             traceback.print_exc(file=sys.stderr, limit=0)

--- a/core/pythonAction/pythonrunner.py
+++ b/core/pythonAction/pythonrunner.py
@@ -71,6 +71,8 @@ class PythonRunner(ActionRunner):
                 else:
                     sys.stderr.write('Invalid virtualenv. Zip file does not include /virtualenv/bin/' + os.path.basename(activate_this_file) + '\n')
                     return False
+            #exec global var define when action init    
+            exec(self.fn, self.global_context)    
             return True
         except Exception:
             traceback.print_exc(file=sys.stderr, limit=0)
@@ -84,7 +86,7 @@ class PythonRunner(ActionRunner):
         try:
             os.environ = env
             self.global_context['param'] = args
-            exec(self.fn, self.global_context)
+            #only exec mainFn when action run
             exec('fun = %s(param)' % self.mainFn, self.global_context)
             result = self.global_context['fun']
         except Exception:


### PR DESCRIPTION
after python action run  success,while pod stay warm state;
current run method will exec below when next invoke:
```
exec(self.fn, self.global_context)
exec('fun = %s(param)' % self.mainFn, self.global_context)
```
the definition outside the main function will be exec every time.
global var(value) previous will be lost,so exec such code at action init may be correct
