### PR TITLE
Add python2Action into settings.gradle

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -18,6 +18,7 @@
 include 'tests'
 
 include 'core:pythonAction'
+include 'core:python2Action'
 include 'core:python3AiAction'
 include 'core:pythonActionLoop'
 


### PR DESCRIPTION
This PR enables the gradlew build for python2Action
Closes-Bug: #61 